### PR TITLE
Add a fix to replace function for each deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ COPY package.json package-lock.json register-runner.sh ${LAMBDA_TASK_ROOT}/
 COPY src/ ${LAMBDA_TASK_ROOT}/src
 COPY infra/ ${LAMBDA_TASK_ROOT}/infra
 
-RUN npm install
+RUN npm ci
 
 CMD [ "src/server.handler" ]

--- a/INSTALLATION_GUIDE.md
+++ b/INSTALLATION_GUIDE.md
@@ -112,7 +112,8 @@ First create an IAM policy, but replace the placeholders in the json example, wi
                 "ecr:InitiateLayerUpload",
                 "ecr:BatchCheckLayerAvailability",
                 "cloudformation:*",
-                "iam:CreateServiceLinkedRole"
+                "iam:CreateServiceLinkedRole",
+                "lambda:RemovePermission"
             ],
             "Resource": "*"
         },

--- a/src/template.yml
+++ b/src/template.yml
@@ -47,7 +47,7 @@ Resources:
   GHAppWebhookConsumerLambda:
     Type: AWS::Serverless::Function
     Properties:
-      FunctionName: !Ref functionName
+      FunctionName: !Join [ "-", [ !Ref functionName, !Ref timestamp ] ]
       Description: Basic Auth Funtion
       Role: !Ref awsRole
       MemorySize: 512


### PR DESCRIPTION
Hi @jgiannuzzi . This PR adds a fix to the Lambda function deployment workflow, and enables AWS SAM to replace the function entirely, thus pulling the latest code, and other new changes, so we don't have to delete a CF stack. Also, Dockerfile is now running `npm ci`. I have already updated the IAM Policy