### PR TITLE
Add config per label and retry mechanism

### DIFF
--- a/.github/workflows/aws_sam.yml
+++ b/.github/workflows/aws_sam.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Transform YAML to JSON and echo to file
+      - name: Echo config to file
         run: echo "${{ vars.CONFIG }}" > ./config.yml
       
       - uses: actions/setup-node@v3
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Transform YAML to JSON and echo to file
+      - name: Echo config to file
         run: echo "${{ vars.CONFIG }}" > ./config.yml
       
       - uses: actions/setup-node@v3

--- a/.github/workflows/aws_sam.yml
+++ b/.github/workflows/aws_sam.yml
@@ -9,8 +9,12 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    environment: protected
     steps:
       - uses: actions/checkout@v3
+
+      - name: Transform YAML to JSON and echo to file
+        run: echo "${{ vars.CONFIG }}" > ./config.yml
       
       - uses: actions/setup-node@v3
         with:
@@ -30,6 +34,9 @@ jobs:
     needs: test
     steps:
       - uses: actions/checkout@v3
+
+      - name: Transform YAML to JSON and echo to file
+        run: echo "${{ vars.CONFIG }}" > ./config.yml
       
       - uses: actions/setup-node@v3
         with:
@@ -58,7 +65,6 @@ jobs:
         env:
           AWS_ARN_ROLE: ${{ secrets.AWS_ARN_ROLE }}
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-          JOB_FILTER: ${{ secrets.JOB_FILTER }}
           HOSTED_ZONE_ID: ${{ secrets.HOSTED_ZONE_ID }}
           FULL_DOMAIN_NAME: ${{ secrets.FULL_DOMAIN_NAME }}
           TLS_CERTIFICATE_ARN: ${{ secrets.TLS_CERTIFICATE_ARN }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ ghrunner-app.json
 .gcloudignore
 .aws-sam
 dist
+config.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN yum install tar gzip -y \
 
 ENV PULUMI_HOME=/tmp/.pulumi
 
-COPY package.json package-lock.json register-runner.sh ${LAMBDA_TASK_ROOT}/
+COPY package.json package-lock.json register-runner.sh config.yml ${LAMBDA_TASK_ROOT}/
 COPY src/ ${LAMBDA_TASK_ROOT}/src
 COPY infra/ ${LAMBDA_TASK_ROOT}/infra
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ up: build
 		--no-confirm-changeset \
 		--debug \
 		--image-repository ${ECR_REPO}/ghrunner-app \
-		--parameter-overrides "awsRole=${AWS_ARN_ROLE} functionName=${function_name} githubJobFilter=${JOB_FILTER} hostedZoneId=${HOSTED_ZONE_ID} fullDomainName=${FULL_DOMAIN_NAME} tlsCertificateArn=${TLS_CERTIFICATE_ARN} pulumiBackendUrl=${PULUMI_BACKEND_URL} ecrRepo=${ECR_REPO}/ghrunner-app timestamp=${timestamp} machineType=${MACHINE_TYPE} machineImage=${MACHINE_IMAGE} bootDiskSizeInGB=${BOOT_DISK_SIZE_IN_GB} bootDiskType=${BOOT_DISK_TYPE}" \
+		--parameter-overrides "awsRole=${AWS_ARN_ROLE} functionName=${function_name} hostedZoneId=${HOSTED_ZONE_ID} fullDomainName=${FULL_DOMAIN_NAME} tlsCertificateArn=${TLS_CERTIFICATE_ARN} pulumiBackendUrl=${PULUMI_BACKEND_URL} ecrRepo=${ECR_REPO}/ghrunner-app timestamp=${timestamp}" \
 		|| exit 1
 
 down:

--- a/config.yml.example
+++ b/config.yml.example
@@ -1,0 +1,10 @@
+cuda:
+  machineType: g4dn.xlarge
+  machineImage: gross-cuda-nvidia-ghrunner-23090-amd64
+  bootDiskSizeInGB: 100
+  bootDiskType: gp2
+opencl:
+  machineType: t2.micro
+  machineImage: gross-cuda-nvidia-ghrunner-23090-amd64
+  bootDiskSizeInGB: 100
+  bootDiskType: gp2

--- a/configSchema.json
+++ b/configSchema.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "patternProperties": {
+      ".*": {
+        "type": "object",
+        "properties": {
+          "machineType": { "type": "string" },
+          "machineImage": { "type": "string" },
+          "bootDiskSizeInGB": { "type": "number" },
+          "bootDiskType": { "type": "string" }
+        },
+        "required": ["machineType", "machineImage", "bootDiskSizeInGB", "bootDiskType"]
+      }
+    },
+    "additionalProperties": false
+  }
+  

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,9 @@
         "@probot/adapter-aws-lambda-serverless": "^3.0.2",
         "@pulumi/aws": "^5.34.0",
         "@pulumi/pulumi": "^3.61.0",
+        "ajv": "^8.12.0",
         "dotenv": "^8.6.0",
+        "js-yaml": "^3.14.1",
         "mustache": "^4.2.0",
         "octokit": "^2.0.14",
         "probot": "^12.2.3",
@@ -4299,7 +4301,6 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -5582,8 +5583,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -6667,8 +6667,7 @@
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -9670,7 +9669,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -9679,7 +9677,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -13657,7 +13654,6 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -14627,8 +14623,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -15375,8 +15370,7 @@
     "json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -17748,7 +17742,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       },
@@ -17756,8 +17749,7 @@
         "punycode": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-          "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-          "dev": true
+          "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "start": "docker run -p 9000:8080 --name ghrunner-app-lambda --env-file .env -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN --rm ghrunner-app-lambda",
-    "test": "JOB_FILTER=cuda mocha tests",
+    "test": "mocha tests",
     "build": "docker build -t ghrunner-app-lambda ."
   },
   "license": "ISC",
@@ -12,7 +12,9 @@
     "@probot/adapter-aws-lambda-serverless": "^3.0.2",
     "@pulumi/aws": "^5.34.0",
     "@pulumi/pulumi": "^3.61.0",
+    "ajv": "^8.12.0",
     "dotenv": "^8.6.0",
+    "js-yaml": "^3.14.1",
     "mustache": "^4.2.0",
     "octokit": "^2.0.14",
     "probot": "^12.2.3",

--- a/src/app.js
+++ b/src/app.js
@@ -1,7 +1,6 @@
 const { createOrDelete } = require("../infra")
 const uuid = require("uuid");
-
-const jobFilter = process.env.JOB_FILTER;
+const { convertYamlToJson } = require('./util');
 
 /**
  * @param {import('probot').Probot} app
@@ -12,14 +11,15 @@ const probotApp = async (app) => {
     if(Array.isArray(context.payload.workflow_job.labels) && context.payload.workflow_job.labels.length > 0){
       var labels = context.payload.workflow_job.labels.join(',');
 
-      if(jobFilter === labels){
-        console.info(`CtxID=[${context.id}]. JobID=[${context.payload.workflow_job.id}]. Message=Received workflow job is a candidate for self hosted runners. JobUrl=[${context.payload.workflow_job.url}]`);
+      const configPerLabel = convertYamlToJson('config.yml')
+
+      if(configPerLabel.hasOwnProperty(labels)){
+        console.info(`CtxID=[${context.id}]. JobID=[${context.payload.workflow_job.id}]. Labels=[${labels}]. Message=Received workflow job is a candidate for self hosted runners. JobUrl=[${context.payload.workflow_job.url}]`);
         console.log(`Received event from job: ${context.payload.workflow_job.id}. Action: ${context.payload.action}. Name: ${context.payload.workflow_job.name}`);
         var action = context.payload.action === 'completed' ? context.payload.action : (context.payload.action === 'queued' ? "requested": null);
         
         if(action !== null){
           console.log(`Job: ${context.payload.workflow_job.id}. Action: ${action}. Name: ${context.payload.workflow_job.name}. Run id: ${context.payload.workflow_job.run_id.toString()}. Run attempt: ${context.payload.workflow_job.run_attempt.toString()}. Labels: ${labels}`);
-  
           try {
             let stack_name; 
             if(action === "completed"){
@@ -27,25 +27,24 @@ const probotApp = async (app) => {
             } else {
               stack_name = `ghrunner-${uuid.v4()}`;
             }
-  
+
             let repo_full_name = context.payload.repository.full_name.split('/');
             let config = {
-              machineType: process.env.MACHINE_TYPE,
-              machineImage: process.env.MACHINE_IMAGE,
-              bootDiskSizeInGB: process.env.BOOT_DISK_SIZE_IN_GB,
-              bootDiskType: process.env.BOOT_DISK_TYPE,
+              machineType: configPerLabel[labels].machineType,
+              machineImage: configPerLabel[labels].machineImage,
+              bootDiskSizeInGB: configPerLabel[labels].bootDiskSizeInGB,
+              bootDiskType: configPerLabel[labels].bootDiskType,
               owner: repo_full_name[0],
               repo: repo_full_name[1],
               labels: labels
             }
-            
             await createOrDelete(context, action, stack_name, config);
           } catch (error) {
             console.log(`Error occured while trying to destroy/create infrastructure. Error: ${error}`);
           }
         }
       }else {
-        console.debug(`CtxID=[${context.id}]. JobID=[${context.payload.workflow_job.id}]. Message=Received workflow job is not a candidate for self hosted runners. JobUrl=[${context.payload.workflow_job.url}]`);
+        console.debug(`CtxID=[${context.id}]. JobID=[${context.payload.workflow_job.id}]. Labels=[${labels}]. Message=Received workflow job is not a candidate for self hosted runners. JobUrl=[${context.payload.workflow_job.url}]`);
       }
     }
   });

--- a/src/template.yml
+++ b/src/template.yml
@@ -9,9 +9,6 @@ Parameters:
   functionName:
     Description: The AWS Lambda's Function name
     Type: String
-  githubJobFilter:
-    Description: The Job Filter
-    Type: String
   hostedZoneId:
     Description: ID of the Hosted zone where static record set will be created
     Type: String
@@ -53,7 +50,7 @@ Resources:
       MemorySize: 512
       EphemeralStorage:
         Size: 10240
-      Timeout: 300
+      Timeout: 900
       PackageType: Image
       ImageUri: !Join [ ":", [ !Ref ecrRepo, 'latest' ] ]
       Tags:
@@ -67,7 +64,6 @@ Resources:
             Method: POST
       Environment:
         Variables:
-          JOB_FILTER: !Ref githubJobFilter
           PULUMI_BACKEND_URL: !Ref pulumiBackendUrl
           DEPLOYMENT_TIMESTAMP: !Ref timestamp
           MACHINE_TYPE: !Ref machineType 

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const yaml = require('js-yaml');
+
+function convertYamlToJson(yamlFilePath) {
+    try {
+        const fileContents = fs.readFileSync(yamlFilePath, 'utf8');
+        return yaml.load(fileContents);
+    } catch (e) {
+        console.error('Error reading or parsing YAML:', e);
+        throw e;
+    }
+}
+
+module.exports = { convertYamlToJson };

--- a/tests/json-schema.js
+++ b/tests/json-schema.js
@@ -1,0 +1,19 @@
+const Ajv = require('ajv');
+const schema = require('../configSchema.json');
+const assert = require('assert');
+const { convertYamlToJson } = require('../src/util');
+
+const ajv = new Ajv();
+
+describe('Config Validation', () => {
+  it('should validate the config against the schema', () => {
+    const validate = ajv.compile(schema);
+    const config = convertYamlToJson('config.yml');
+    const valid = validate(config);
+
+    if (!valid) {
+      console.error(validate.errors);
+    }
+    assert.strictEqual(valid, true, "Config does not match the schema");
+  });
+});

--- a/tests/workflow_job.js
+++ b/tests/workflow_job.js
@@ -19,7 +19,7 @@ describe('probotApp', () => {
   });
 
   describe('on workflow_job event', () => {
-    it('should log message when job name includes JOB_FILTER', async () => {
+    it('should log message when job labels includes cuda', async () => {
       const consoleSpy = sinon.spy(console, 'info');
       await probot.receive({ name: 'workflow_job', payload: mockPayload, id: "123456" });
       assert.strictEqual(consoleSpy.called, true);


### PR DESCRIPTION
This PR introduces a config file in yml format, that is picked up by the backend, which then looks for the config params by workflow job label. If the label exists, self hosted runner will be deployed for that job. If the label does not exist, runner will not be deployed. Also, new retry mechanism is added to retry stack.refresh and stack.destroy actions.

Before merging, please add an environment variable (not a secret) to your `protected` environment:
- [x] env var name: `CONFIG`
- [x] value:
```
ubuntu-20.04-arm64:
  machineType: t4g.xlarge
  machineImage: gross-pwsh-libicu-ghrunner-23090-arm64
  bootDiskSizeInGB: 500
  bootDiskType: gp2
```
- [x] feel free to remove current env vars: `JOB_FILTER`, `MACHINE_IMAGE`, `MACHINE_TYPE`, `BOOT_DISK_SIZE_IN_GB`, `BOOT_DISK_TYPE`