### PR TITLE
Parameterise Pulumi version

### DIFF
--- a/.github/workflows/aws_sam.yml
+++ b/.github/workflows/aws_sam.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - parameterize-pulumi-version
   workflow_dispatch:
 
 jobs:
@@ -14,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Transform YAML to JSON and echo to file
+      - name: Echo config to file
         run: echo "${{ vars.CONFIG }}" > ./config.yml
       
       - uses: actions/setup-node@v3
@@ -36,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Transform YAML to JSON and echo to file
+      - name: Echo config to file
         run: echo "${{ vars.CONFIG }}" > ./config.yml
       
       - uses: actions/setup-node@v3
@@ -49,7 +48,7 @@ jobs:
         env:
           PULUMI_VERSION: ${{ vars.PULUMI_VERSION }}
 
-      - uses: aws-actions/configure-aws-credentials@v1.7.0
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/aws_sam.yml
+++ b/.github/workflows/aws_sam.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - parameterize-pulumi-version
   workflow_dispatch:
 
 jobs:
@@ -13,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Echo config to file
+      - name: Transform YAML to JSON and echo to file
         run: echo "${{ vars.CONFIG }}" > ./config.yml
       
       - uses: actions/setup-node@v3
@@ -35,15 +36,18 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Echo config to file
+      - name: Transform YAML to JSON and echo to file
         run: echo "${{ vars.CONFIG }}" > ./config.yml
       
       - uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: npm
+      
       - name: Build docker image
         run: npm run build
+        env:
+          PULUMI_VERSION: ${{ vars.PULUMI_VERSION }}
 
       - uses: aws-actions/configure-aws-credentials@v1.7.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM public.ecr.aws/lambda/nodejs:16
 
-# ENV PATH="/root/.pulumi/bin:${PATH}"
+ARG PULUMI_VERSION=3.61.0
 RUN yum install tar gzip -y \
-    && curl -fsSL https://get.pulumi.com | sh \
+    && curl -fsSL https://get.pulumi.com | sh -s -- --version $PULUMI_VERSION \
     && mv ~/.pulumi/bin/* /bin/ \
     && pulumi version --non-interactive
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Check if PULUMI_VERSION is set and non-empty
+if [[ -n "$PULUMI_VERSION" ]]; then
+  docker build --build-arg PULUMI_VERSION=$PULUMI_VERSION -t ghrunner-app-lambda .
+else
+  docker build -t ghrunner-app-lambda .
+fi

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "start": "docker run -p 9000:8080 --name ghrunner-app-lambda --env-file .env -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN --rm ghrunner-app-lambda",
     "test": "RUN_CTX=test mocha tests",
-    "build": "docker build -t ghrunner-app-lambda ."
+    "build": "./docker-build.sh"
   },
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
Hi @jgiannuzzi . This PR introduces the parameterised Dockerfile for installing Pulumi. Pulumi version is set to default in Dockerfile to 3.61.0. If you want to override this value, add an env variable (not a secret) to the `protected` environment called `PULUMI_VERSION` and set it to the version you wish to use (without `v` in version). 

Each time you wish to change the version, just change the value of the env var, and redeploy/rerun the deployment workflow.